### PR TITLE
Left right listeners

### DIFF
--- a/client/components/Gallery.jsx
+++ b/client/components/Gallery.jsx
@@ -13,12 +13,26 @@ class Gallery extends React.Component {
     this.handleNextClick = this.handleNextClick.bind(this);
     this.handlePreviousClick = this.handlePreviousClick.bind(this);
     this.closePopupGallery = this.closePopupGallery.bind(this);
+    this.handleKeypress = this.handleKeypress.bind(this);
   }
 
   handleClick(e) {
     this.setState({
       selected: e.target.id,
     });
+    document.addEventListener('keydown', this.handleKeypress);
+  }
+
+  handleKeypress(event) {
+    switch (event.key) {
+      case 'ArrowRight':
+        this.handleNextClick();
+        break;
+      case 'ArrowLeft':
+        this.handlePreviousClick();
+        break;
+      default:
+    }
   }
 
   handleNextClick() {
@@ -47,6 +61,7 @@ class Gallery extends React.Component {
     this.setState({
       selected: '',
     });
+    document.removeEventListener('keydown', this.handleKeypress);
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "jest": {
     "setupFilesAfterEnv": [
       "./setupTests.js"
-    ],
-    "testEnvironment": "node"
+    ]
   }
 }

--- a/tests/Gallery.test.js
+++ b/tests/Gallery.test.js
@@ -81,4 +81,25 @@ describe('Gallery', () => {
     closePopoutDiv.simulate('click');
     expect(wrapper.find('.big-image').length).toEqual(0);
   });
+
+  it('handles keypress events to navigate through the popup gallery', () => {
+    const wrapper = shallow(
+      <Gallery images={testData} />,
+    );
+    const image = wrapper.find('ImgDouble').first();
+    const map = {};
+    document.addEventListener = jest.fn((event, cb) => {
+      map[event] = cb;
+    });
+    image.props().onClick({
+      target: {
+        id: 0,
+      },
+    });
+    expect(wrapper.state('selected')).toEqual(0);
+    map.keydown({ key: 'ArrowRight' });
+    expect(wrapper.state('selected')).toEqual(1);
+    map.keydown({ key: 'ArrowLeft' });
+    expect(wrapper.state('selected')).toEqual(0);
+  });
 });

--- a/tests/Gallery.test.js
+++ b/tests/Gallery.test.js
@@ -80,6 +80,5 @@ describe('Gallery', () => {
 
     closePopoutDiv.simulate('click');
     expect(wrapper.find('.big-image').length).toEqual(0);
-
   });
 });


### PR DESCRIPTION
Before this feature, a user was only able to navigate through the popup gallery with buttons. Now they can press left or right on the keyboard to achieve the same thing.